### PR TITLE
Fix return in FreeBuffer

### DIFF
--- a/KT_BinIO.cpp
+++ b/KT_BinIO.cpp
@@ -50,4 +50,5 @@ uint32_t KT_BinIO::FreeBuffer()
 {
     free(pReadBuff);
     free(pWriteBuff);
+    return 1;
 }


### PR DESCRIPTION
Got this

```
tools/vnproch55x/KT_BinIO.cpp: In member function ‘uint32_t KT_BinIO::FreeBuffer()’:
tools/vnproch55x/KT_BinIO.cpp:53:1: warning: no return statement in function returning non-void [-Wreturn-type]
   53 | }
      | ^
```